### PR TITLE
Dockerize broadcast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ config.json
 pivideo.h264
 static/dist
 data
+broadcaster-src/.env

--- a/broadcaster-src/Dockerfile
+++ b/broadcaster-src/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.8-buster
+RUN apt update && apt install curl gpac -y --fix-missing
+
+ENV LD_LIBRARY_PATH=/opt/vc/lib
+WORKDIR /usr/src/app
+
+COPY . .
+
+CMD ["python3", "broadcast.py"]

--- a/broadcaster-src/Dockerfile
+++ b/broadcaster-src/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:3.8-buster
-RUN apt update && apt install curl gpac -y --fix-missing
-
+FROM ubuntu:latest
+RUN apt update && apt install curl python3-pip gpac -y
 ENV LD_LIBRARY_PATH=/opt/vc/lib
+
 WORKDIR /usr/src/app
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
 
 COPY . .
 
-CMD ["python3", "broadcast.py"]
+CMD python3 broadcast.py

--- a/broadcaster-src/README.md
+++ b/broadcaster-src/README.md
@@ -1,5 +1,8 @@
-1. Install docker and docker-compose
-2. Setup the camera to be accessible from within docker
- (Instructions originally from https://www.losant.com/blog/how-to-access-the-raspberry-pi-camera-in-docker)
- create a file at /etc/udev/rules.d/99-camera.rules with the text: SUBSYSTEM=="vchiq",MODE="0666"
-3. ./start_broadcast.sh
+# Camera Pi Setup
+1. Install `docker` and `docker-compose`
+2. Setup the camera to be accessible from within docker:
+ create a file at /etc/udev/rules.d/99-camera.rules with the text: `SUBSYSTEM=="vchiq",MODE="0666"`
+ ([Instructions from here](https://www.losant.com/blog/how-to-access-the-raspberry-pi-camera-in-docker))
+3. Create a .env file with an `OVERSEER_SERVER` key which is the IP/host of the Overseer server, the machine
+ that hosts the website.
+4. From within this folder run `./start_broadcast.sh`

--- a/broadcaster-src/README.md
+++ b/broadcaster-src/README.md
@@ -1,0 +1,5 @@
+1. Install docker and docker-compose
+2. Setup the camera to be accessible from within docker
+ (Instructions originally from https://www.losant.com/blog/how-to-access-the-raspberry-pi-camera-in-docker)
+ create a file at /etc/udev/rules.d/99-camera.rules with the text: SUBSYSTEM=="vchiq",MODE="0666"
+3. ./start_broadcast.sh

--- a/broadcaster-src/box.sh
+++ b/broadcaster-src/box.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-MP4Box -dash 15000 -add $3/pivideo.h264:fps=$1 $3/stream.mp4
+MP4Box -dash 15000 -add $3/pivideo.h264:fps=$1 /broadcast-video/stream.mp4
 rm $3/pivideo.h264
 curl http://$2:3200/update

--- a/broadcaster-src/broadcast.py
+++ b/broadcaster-src/broadcast.py
@@ -4,21 +4,18 @@ import datetime as dt
 import subprocess
 import json
 
-try:
-    file = open('config.json')
-    config = json.load(file)
-    file.close()
-except FileNotFoundError:
-    print('no config.json, make one with these properties:')
-    print('overseer-server: IP/domain name of the overseer server')
-    print('save-directory: directory path to a web server root to save videos to (a small ram disk is recommended)')
-
-print("Overseer Broadcast camera running!")
-
 recording_time = 10
 fps = 10
 quality = 32
 silence_logs = True
+save_directory = '/broadcast-temp'
+
+overseer_server = os.environ['OVERSEER_SERVER']
+if not overseer_server:
+    print("Missing .env with OVERSEER_SERVER defined.")
+    sys.exit(1)
+
+print("Overseer Broadcast camera running!")
 
 camera = picamera.PiCamera(resolution=(1280, 720), framerate=fps)
 # buffer more seconds than we actually will save
@@ -32,7 +29,7 @@ while True:
     while (dt.datetime.now() - start).seconds < recording_time:
         camera.annotate_text = dt.datetime.now().strftime('%Y-%m-%d %I:%M:%S %p')
         camera.wait_recording(0.1)
-    stream.copy_to(os.path.join(config['save-directory'], 'pivideo.h264'), seconds=recording_time)
+    stream.copy_to(os.path.join(save_directory, 'pivideo.h264'), seconds=recording_time)
     # requesting a keyframe now will mean it will have a key frame to split the video at,
     # instead of having to throw away a section of video until the first keyframe for the next segment
     start = dt.datetime.now()
@@ -41,6 +38,6 @@ while True:
     # ignore all logs, seems we can't just ignore stdout because mp4box logs stdout to stderr,
     # without this, the forever logs will grow and eventually fill the entire disk
     log_location = subprocess.DEVNULL if silence_logs else None
-    subprocess.Popen(['broadcaster-src/box.sh', str(fps), config['overseer-server'], config['save-directory']], stderr=log_location, stdout=log_location)
+    subprocess.Popen(['broadcaster-src/box.sh', str(fps), overseer_server, save_directory], stderr=log_location, stdout=log_location)
 
 camera.stop_recording()

--- a/broadcaster-src/broadcast.py
+++ b/broadcaster-src/broadcast.py
@@ -1,8 +1,11 @@
 import os
 import picamera
-import datetime as dt
+from datetime import datetime
 import subprocess
 import json
+import sys
+from dotenv import load_dotenv
+load_dotenv()
 
 recording_time = 10
 fps = 10
@@ -10,34 +13,32 @@ quality = 32
 silence_logs = True
 save_directory = '/broadcast-temp'
 
-overseer_server = os.environ['OVERSEER_SERVER']
-if not overseer_server:
-    print("Missing .env with OVERSEER_SERVER defined.")
+try:
+    overseer_server = os.environ['OVERSEER_SERVER']
+except KeyError as e:
+    print(f'Missing .env file with {e.args[0]} defined.')
     sys.exit(1)
 
 print("Overseer Broadcast camera running!")
 
 camera = picamera.PiCamera(resolution=(1280, 720), framerate=fps)
-# buffer more seconds than we actually will save
 stream = picamera.PiCameraCircularIO(camera, seconds=recording_time)
 
 camera.annotate_background = picamera.Color('black')
 camera.start_recording(stream, format='h264', quality=quality)
-start = dt.datetime.now()
+start = datetime.now()
 
 while True:
-    while (dt.datetime.now() - start).seconds < recording_time:
-        camera.annotate_text = dt.datetime.now().strftime('%Y-%m-%d %I:%M:%S %p')
+    while (datetime.now() - start).seconds < recording_time:
+        camera.annotate_text = datetime.now().strftime('%Y-%m-%d %I:%M:%S %p')
         camera.wait_recording(0.1)
     stream.copy_to(os.path.join(save_directory, 'pivideo.h264'), seconds=recording_time)
     # requesting a keyframe now will mean it will have a key frame to split the video at,
     # instead of having to throw away a section of video until the first keyframe for the next segment
-    start = dt.datetime.now()
+    start = datetime.now()
     camera.request_key_frame()
     
-    # ignore all logs, seems we can't just ignore stdout because mp4box logs stdout to stderr,
-    # without this, the forever logs will grow and eventually fill the entire disk
     log_location = subprocess.DEVNULL if silence_logs else None
-    subprocess.Popen(['broadcaster-src/box.sh', str(fps), overseer_server, save_directory], stderr=log_location, stdout=log_location)
+    subprocess.Popen(['./box.sh', str(fps), overseer_server, save_directory], stderr=log_location, stdout=log_location)
 
 camera.stop_recording()

--- a/broadcaster-src/docker-compose.yml
+++ b/broadcaster-src/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3.7"
+services:
+    broadcast:
+        build:
+            context: .
+        devices:
+            - "/dev/vchiq:/dev/vchiq"
+        volumes:
+            - type: bind
+              source: /opt/vc
+              target: /opt/vc
+            - type: tmpfs
+              target: /broadcast-temp
+              tmpfs:
+                  size: 64m
+            - type: volume
+              source: video
+              target: /broadcast-video
+        restart: always
+    nginx:
+        image: nginx:1.18
+        volumes:
+            - type: volume
+              source: video
+              target: /broadcast-video
+            - type: bind
+              source: ./nginx.conf
+              target: /etc/nginx/nginx.conf
+        ports: 
+            - 80:80
+        restart: always
+volumes:
+    video:

--- a/broadcaster-src/docker-compose.yml
+++ b/broadcaster-src/docker-compose.yml
@@ -4,11 +4,9 @@ services:
         build:
             context: .
         devices:
-            - "/dev/vchiq:/dev/vchiq"
+            - /dev/vchiq:/dev/vchiq
+        privileged: true
         volumes:
-            - type: bind
-              source: /opt/vc
-              target: /opt/vc
             - type: tmpfs
               target: /broadcast-temp
               tmpfs:
@@ -16,6 +14,9 @@ services:
             - type: volume
               source: video
               target: /broadcast-video
+            - /opt/vc:/opt/vc:ro
+            - /etc/timezone:/etc/timezone:ro
+            - /etc/localtime:/etc/localtime:ro
         restart: always
     nginx:
         image: nginx:1.18

--- a/broadcaster-src/nginx.conf
+++ b/broadcaster-src/nginx.conf
@@ -1,0 +1,18 @@
+events {
+
+}
+
+http {
+	server {
+		listen 80;
+		root /overseer-broadcast-video;
+
+		add_header Cache-Control "no-cache, no-store, must-revalidate";
+		add_header Pragma "no-cache";
+		add_header Expires "0";
+
+		location / {
+			try_files $uri;
+		}
+	}
+}

--- a/broadcaster-src/nginx.conf
+++ b/broadcaster-src/nginx.conf
@@ -5,14 +5,14 @@ events {
 http {
 	server {
 		listen 80;
-		root /overseer-broadcast-video;
+		root /broadcast-video;
 
 		add_header Cache-Control "no-cache, no-store, must-revalidate";
 		add_header Pragma "no-cache";
 		add_header Expires "0";
 
 		location / {
-			try_files $uri;
+			try_files $uri $uri/ =404;
 		}
 	}
 }

--- a/broadcaster-src/requirements.txt
+++ b/broadcaster-src/requirements.txt
@@ -1,0 +1,2 @@
+python-dotenv==0.13.0
+picamera==1.13

--- a/broadcaster-src/start_broadcast.sh
+++ b/broadcaster-src/start_broadcast.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker-compose up

--- a/broadcaster-src/start_broadcast.sh
+++ b/broadcaster-src/start_broadcast.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker-compose up
+docker-compose up --build -d

--- a/package.json
+++ b/package.json
@@ -4,8 +4,6 @@
   "description": "View a network of local raspberry pi cameras.",
   "main": "app.js",
   "scripts": {
-    "broadcast": "export NODE_ENV=production && forever start -c python3 broadcaster-src/broadcast.py",
-    "deploy-broadcast": "forever stopall && git pull && npm run broadcast",
     "start": "forever start overseer-src/server.js",
     "stop": "forever stop overseer-src/server.js",
     "dev": "nodemon overseer-src/server.js --ignore data/",


### PR DESCRIPTION
Now using docker and docker-compose to run the camera script. This is all in an effort to reduce the amount of time and effort it takes to setup a new pi for broadcasting, as you no longer need to manually install nginx, nodejs, forever, and MP4Box, configure nginx, create a tmpfs partition, or make the camera auto-start on boot (something I hadn't yet gotten working personally before this).

It should be as simple as installing docker and docker-compose, adding one file (detailed in the readme) to change camera permissions, and creating a `.env` file with an `OVERSEER_SERVER` key, and running `start_broadcast.sh`.

Config for `broadcast.py` is done in a `.env` file now instead of the `config.json` file, a message will be logged if there are any missing environment variables so more configuration options can be added in the future.

Nodejs and forever were previously used to run the broadcast script in detached mode, but that's no longer needed as it's handled by docker-compose.